### PR TITLE
feat(deck): progress slot

### DIFF
--- a/src/slidem-deck.js
+++ b/src/slidem-deck.js
@@ -81,7 +81,7 @@ export class SlidemDeck extends GluonElement {
       <div class="slides" part="slides">
         <slot id="slides"></slot>
       </div>
-      <div id="progress" part="progress"></div>
+      <div id="progress" part="progress"><slot name="progress" id="progressSlot"></slot></div>
       <div id="timer" part="timer"></div>
       <gluon-keybinding id="timerToggle" key="t"></gluon-keybinding>
       <gluon-keybinding id="presenterToggle" key="p"></gluon-keybinding>
@@ -271,6 +271,10 @@ export class SlidemDeck extends GluonElement {
           transform: translate(28%, 0) scale(0.35) !important; /* Force presenter layout */
         }
 
+        :host([presenter]) #progress {
+          transform: translate(-20%, 25vh) scale(0.5);
+        }
+
         .slides ::slotted([active]) {
           z-index: 2;
         }
@@ -351,7 +355,7 @@ export class SlidemDeck extends GluonElement {
 
     // Create dots for progress bar
     this.slides.forEach(() => {
-      this.$.progress.appendChild(document.createElement('div'));
+      this.$.progressSlot.appendChild(document.createElement('div'));
     });
 
     /**
@@ -398,11 +402,11 @@ export class SlidemDeck extends GluonElement {
       if (this.previousSlide !== undefined) {
         this.slides[this.previousSlide].removeAttribute('active');
         this.slides[this.previousSlide].setAttribute('previous', '');
-        this.$.progress.children[this.previousSlide].classList.remove('active');
+        this.$.progressSlot.children[this.previousSlide].classList.remove('active');
         this.oldPreviousSlide = this.previousSlide;
       }
 
-      this.$.progress.children[this.currentSlide].classList.add('active');
+      this.$.progressSlot.children[this.currentSlide].classList.add('active');
 
       this.previousSlide = this.currentSlide;
     });


### PR DESCRIPTION
Allows slotting a custom progress indicator which overrides the default progress dots