### PR TITLE
feat: add `defineSteps` public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,25 @@ class SlidemSpeakerSlide extends SlidemSlide {
 customElements.define(SlidemSpeakerSlide.id, SlidemSpeakerSlide);
 ```
 
+### Escape Hatches
+
+Occasionally, when defining custom slide elements, you may with to override the 
+default behaviour. One example would be when your slides' content is contained 
+within their shadow roots, perhaps by way of [Declarative Shadow DOM][dsd].
+
+In that case, you can imperatively define your slide's steps using the 
+`defineSteps(nodelist)` method:
+
+```js
+class DeclarativeShadowSlide extends SlidemSlideBase {
+  async connectedCallback() {
+    super.connectedCallback();
+    await polyfillDeclarativeShadowDOM(this);
+    this.defineSteps(this.shadowRoot.querySelectorAll('[reveal]'));
+  }
+}
+```
+
 See [`index.html`](./blob/master/index.html) for a complete example.
+
+[dsd]: https://developer.chrome.com/articles/declarative-shadow-dom/

--- a/src/slidem-slide-base.js
+++ b/src/slidem-slide-base.js
@@ -56,12 +56,7 @@ export class SlidemSlideBase extends HTMLElement {
 
   connectedCallback() {
     SlidemSlideBase.#instances.add(this);
-    this.#steps = Array.from(this.querySelectorAll('[reveal]'));
-    this.steps = this.#steps.length;
-    this.#resizeContent();
-    this.#steps.forEach((step, i) => step.setAttribute('step', i + 2));
-    if (this.#steps.length)
-      this.#steps[0].previousElementSibling?.setAttribute('step', 1);
+    this.defineSteps(this.querySelector('[reveal]'));
   }
 
   disconnectedCallback() {
@@ -77,6 +72,28 @@ export class SlidemSlideBase extends HTMLElement {
       }
       this.#setStep(step);
     }
+  }
+
+  /**
+   * Imperatively set the list of steps for this slide
+   * @example when the steps are located in the shadow root
+   *          ```javascript
+   *          class DeclarativeShadowSlide extends SlidemSlideBase {
+   *            async connectedCallback() {
+   *              super.connectedCallback();
+   *              await polyfillDeclarativeShadowDOM(this);
+   *              this.defineSteps(this.shadowRoot.querySelectorAll('[reveal]'));
+   *            }
+   *          }
+   *          ```
+   */
+  defineSteps(nodelist) {
+    this.#steps = Array.from(nodelist ?? []);
+    this.steps = this.#steps.length;
+    this.#resizeContent();
+    this.#steps.forEach((step, i) => step.setAttribute('step', i + 2));
+    if (this.#steps.length)
+      this.#steps[0].previousElementSibling?.setAttribute('step', 1);
   }
 
   #setStep(step) {


### PR DESCRIPTION
this is an escape hatch for advanced usage, ordinary users don't need to use this.

some server-side frameworks will (sometimes helpfully, sometimes annoyingly) "compile away" your slots, and move, rather than project your content

Source (an imaginary framework SFC format):
```html
<template framework:mode="dsd">
  <slot></slot> <!-- it's a trap! framework appends, doesn't project -->
</template>
```
Source (light DOM):
```html
<dsd-slide>
  <ul>
    <li reveal>A</li>
    <li reveal>B</li>
  <ul>
</dsd-slide>
```

Result:
```html
<dsd-slide>
  <template shadowrootmode="open">
    <ul>
      <li reveal>A</li>
      <li reveal>B</li>
    </ul>
  </template>
</dsd-slide>
```

## Alternatives
> Frameworks shouldn't do that

Agreed! but in the mean time they do do that.

> Make more internal state public

not ideal. Better to just pass a reference, like so.